### PR TITLE
Add RL TicTacToe demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
-# RL Demo
+# RL Demo: Tic Tac Toe
+
+This repo contains a minimal reinforcement learning demo for Tic Tac Toe.
+It uses a simple Q-learning agent.
+
+## Setup
+
+Install [`uv`](https://docs.astral.sh/uv/) and create a virtual environment:
+
+```bash
+pip install uv
+uv venv .venv
+source .venv/bin/activate
+uv pip install -e .
+```
+
+## Training
+
+Run `train.py` to train the agent against a random opponent:
+
+```bash
+python train.py
+```
+
+This creates `q_table.pkl` which stores the learned Q-values.
+
+## Playing
+
+Use `play.py` to play games between agents of different abilities. The `--x` and `--o` options select the type of agent playing as X and O:
+
+- `trained` &ndash; load Q-values from `q_table.pkl`
+- `untrained` &ndash; fresh Q-learning agent (acts mostly randomly)
+- `random` &ndash; completely random moves
+
+Example: play a trained X against an untrained O:
+
+```bash
+python play.py --x trained --o untrained
+```
+
+

--- a/agent.py
+++ b/agent.py
@@ -1,0 +1,49 @@
+import random
+import pickle
+
+class QAgent:
+    def __init__(self, symbol, epsilon=0.1, alpha=0.5, gamma=0.9):
+        self.q = {}
+        self.symbol = symbol
+        self.epsilon = epsilon
+        self.alpha = alpha
+        self.gamma = gamma
+
+    def get_q(self, state, action):
+        return self.q.get((state, action), 0.0)
+
+    def choose_action(self, env, explore=True):
+        actions = env.available_actions()
+        if explore and random.random() < self.epsilon:
+            return random.choice(actions)
+        qs = [self.get_q(tuple(env.board), a) for a in actions]
+        max_q = max(qs)
+        best_actions = [a for a, q in zip(actions, qs) if q == max_q]
+        return random.choice(best_actions)
+
+    def update(self, state, action, reward, next_state, done):
+        old_q = self.get_q(state, action)
+        next_max = 0
+        if not done:
+            next_actions = [self.get_q(next_state, a) for a in range(9)]
+            next_max = max(next_actions)
+        new_q = old_q + self.alpha * (reward + self.gamma * next_max - old_q)
+        self.q[(state, action)] = new_q
+
+    def save(self, path):
+        with open(path, 'wb') as f:
+            pickle.dump(self.q, f)
+
+    def load(self, path):
+        with open(path, 'rb') as f:
+            self.q = pickle.load(f)
+
+class RandomAgent:
+    def __init__(self):
+        pass
+
+    def choose_action(self, env, explore=True):
+        return random.choice(env.available_actions())
+
+    def update(self, *args, **kwargs):
+        pass

--- a/play.py
+++ b/play.py
@@ -1,0 +1,50 @@
+import argparse
+from tictactoe import TicTacToe
+from agent import QAgent, RandomAgent
+
+
+def load_agent(name, symbol):
+    if name == 'trained':
+        agent = QAgent(symbol)
+        agent.load('q_table.pkl')
+        return agent
+    if name == 'untrained':
+        return QAgent(symbol)
+    return RandomAgent()
+
+
+def play_game(x_agent, o_agent, render=True):
+    env = TicTacToe()
+    env.reset()
+    done = False
+    while not done:
+        if render:
+            env.render()
+            print()
+        if env.current_player == env.PLAYER_X:
+            action = x_agent.choose_action(env, explore=False)
+        else:
+            action = o_agent.choose_action(env, explore=False)
+        state, reward, done, winner = env.step(action)
+    if render:
+        env.render()
+    if winner == env.PLAYER_X:
+        print("X wins!")
+    elif winner == env.PLAYER_O:
+        print("O wins!")
+    else:
+        print("Draw!")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--x', choices=['trained', 'untrained', 'random'], default='trained')
+    parser.add_argument('--o', choices=['trained', 'untrained', 'random'], default='random')
+    args = parser.parse_args()
+    x_agent = load_agent(args.x, TicTacToe.PLAYER_X)
+    o_agent = load_agent(args.o, TicTacToe.PLAYER_O)
+    play_game(x_agent, o_agent)
+
+
+if __name__ == '__main__':
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "rl-demo"
+version = "0.1.0"
+requires-python = ">=3.8"
+dependencies = []
+
+[project.scripts]
+train-ttt = "train:main"
+play-ttt = "play:main"

--- a/tictactoe.py
+++ b/tictactoe.py
@@ -1,0 +1,55 @@
+class TicTacToe:
+    EMPTY = 0
+    PLAYER_X = 1
+    PLAYER_O = -1
+
+    def __init__(self):
+        self.reset()
+
+    def reset(self):
+        self.board = [self.EMPTY] * 9
+        self.current_player = self.PLAYER_X
+        return tuple(self.board)
+
+    def available_actions(self):
+        return [i for i, v in enumerate(self.board) if v == self.EMPTY]
+
+    def step(self, action):
+        if self.board[action] != self.EMPTY:
+            raise ValueError("Invalid action")
+        self.board[action] = self.current_player
+        winner = self.check_winner()
+        done = winner is not None or not self.available_actions()
+        reward = 0
+        if done:
+            if winner == self.current_player:
+                reward = 1
+            elif winner is None:
+                reward = 0
+            else:
+                reward = -1
+        self.current_player *= -1
+        return tuple(self.board), reward, done, winner
+
+    def check_winner(self):
+        b = self.board
+        lines = [
+            [0,1,2],[3,4,5],[6,7,8],
+            [0,3,6],[1,4,7],[2,5,8],
+            [0,4,8],[2,4,6]
+        ]
+        for line in lines:
+            total = b[line[0]] + b[line[1]] + b[line[2]]
+            if total == 3:
+                return self.PLAYER_X
+            elif total == -3:
+                return self.PLAYER_O
+        return None
+
+    def render(self):
+        symbols = {self.PLAYER_X: 'X', self.PLAYER_O: 'O', self.EMPTY: ' '}
+        for i in range(3):
+            row = [symbols[self.board[3*i+j]] for j in range(3)]
+            print('|'.join(row))
+            if i < 2:
+                print('-'*5)

--- a/train.py
+++ b/train.py
@@ -1,0 +1,27 @@
+from tictactoe import TicTacToe
+from agent import QAgent, RandomAgent
+
+
+def train(episodes=5000, save_path='q_table.pkl'):
+    env = TicTacToe()
+    agent = QAgent(env.PLAYER_X)
+    opponent = RandomAgent()
+    for _ in range(episodes):
+        state = env.reset()
+        done = False
+        while not done:
+            if env.current_player == agent.symbol:
+                action = agent.choose_action(env)
+                next_state, reward, done, winner = env.step(action)
+                agent.update(state, action, reward, next_state, done)
+            else:
+                action = opponent.choose_action(env)
+                next_state, reward, done, winner = env.step(action)
+                agent.update(state, action, -reward, next_state, done)
+            state = next_state
+    agent.save(save_path)
+    print(f"Trained agent saved to {save_path}")
+
+
+if __name__ == "__main__":
+    train()


### PR DESCRIPTION
## Summary
- implement a tiny TicTacToe environment
- implement a simple Q-learning agent and a random baseline
- add a trainer that plays against a random opponent
- create a small CLI to play trained/untrained/random agents
- document how to train and play
- add `uv` based project setup

## Testing
- `python -m py_compile tictactoe.py agent.py train.py play.py`
- `python train.py`
- `python play.py --x untrained --o random`


------
https://chatgpt.com/codex/tasks/task_e_6841fcbc55c8832b8b0df7ff6c8b4677